### PR TITLE
解像度変更した際にタイルグループ間に隙間が空いてしまう不具合修正

### DIFF
--- a/Assets/MyAssets/Prefab/Canvas/GameCanvas.prefab
+++ b/Assets/MyAssets/Prefab/Canvas/GameCanvas.prefab
@@ -469,32 +469,32 @@ PrefabInstance:
     - target: {fileID: 813984799145479429, guid: 131d166453cb55e49bcfbd2464f95099,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 1
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 813984799145479429, guid: 131d166453cb55e49bcfbd2464f95099,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 813984799145479429, guid: 131d166453cb55e49bcfbd2464f95099,
         type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 813984799145479429, guid: 131d166453cb55e49bcfbd2464f95099,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 813984799145479429, guid: 131d166453cb55e49bcfbd2464f95099,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: -300
+      value: 450
       objectReference: {fileID: 0}
     - target: {fileID: 813984799145479429, guid: 131d166453cb55e49bcfbd2464f95099,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: -600
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 813984799145479429, guid: 131d166453cb55e49bcfbd2464f95099,
         type: 3}
@@ -1164,32 +1164,32 @@ PrefabInstance:
     - target: {fileID: 627922129354268189, guid: fde7a2d5efc43f849b08ce82be1f74d3,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 1
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 627922129354268189, guid: fde7a2d5efc43f849b08ce82be1f74d3,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 627922129354268189, guid: fde7a2d5efc43f849b08ce82be1f74d3,
         type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 627922129354268189, guid: fde7a2d5efc43f849b08ce82be1f74d3,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 627922129354268189, guid: fde7a2d5efc43f849b08ce82be1f74d3,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: -300
+      value: 450
       objectReference: {fileID: 0}
     - target: {fileID: 627922129354268189, guid: fde7a2d5efc43f849b08ce82be1f74d3,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: -600
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 627922129354268189, guid: fde7a2d5efc43f849b08ce82be1f74d3,
         type: 3}
@@ -1455,8 +1455,8 @@ PrefabInstance:
     - target: {fileID: 19420579527008308, guid: 4907225511a370949ad2a953bce5a597,
         type: 3}
       propertyPath: offset
-      value: 255
-      objectReference: {fileID: 0}
+      value: 
+      objectReference: {fileID: 3974699117573738486}
     - target: {fileID: 54205170217815112, guid: 4907225511a370949ad2a953bce5a597,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -4270,8 +4270,8 @@ PrefabInstance:
     - target: {fileID: 5075885653159262399, guid: 4907225511a370949ad2a953bce5a597,
         type: 3}
       propertyPath: offset
-      value: 255
-      objectReference: {fileID: 0}
+      value: 
+      objectReference: {fileID: 3974699117573738486}
     - target: {fileID: 5118443129190084420, guid: 4907225511a370949ad2a953bce5a597,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -4585,7 +4585,7 @@ PrefabInstance:
     - target: {fileID: 5629753486037589486, guid: 4907225511a370949ad2a953bce5a597,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 200
+      value: 250
       objectReference: {fileID: 0}
     - target: {fileID: 5629753486037589486, guid: 4907225511a370949ad2a953bce5a597,
         type: 3}
@@ -4860,32 +4860,32 @@ PrefabInstance:
     - target: {fileID: 6090127756866800044, guid: 4907225511a370949ad2a953bce5a597,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 1
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 6090127756866800044, guid: 4907225511a370949ad2a953bce5a597,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 6090127756866800044, guid: 4907225511a370949ad2a953bce5a597,
         type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 6090127756866800044, guid: 4907225511a370949ad2a953bce5a597,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 6090127756866800044, guid: 4907225511a370949ad2a953bce5a597,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: -300
+      value: 450
       objectReference: {fileID: 0}
     - target: {fileID: 6090127756866800044, guid: 4907225511a370949ad2a953bce5a597,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: -600
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6090127756866800044, guid: 4907225511a370949ad2a953bce5a597,
         type: 3}
@@ -5190,7 +5190,7 @@ PrefabInstance:
     - target: {fileID: 6544260375287693367, guid: 4907225511a370949ad2a953bce5a597,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 1800
+      value: 1000
       objectReference: {fileID: 0}
     - target: {fileID: 6607012357756324132, guid: 4907225511a370949ad2a953bce5a597,
         type: 3}
@@ -6935,6 +6935,12 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 6281894969780124446}
   m_PrefabAsset: {fileID: 0}
+--- !u!224 &3974699117573738486 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6918991347202667752, guid: 4907225511a370949ad2a953bce5a597,
+    type: 3}
+  m_PrefabInstance: {fileID: 6281894969780124446}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &30996884738988311 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 6288108861354959369, guid: 4907225511a370949ad2a953bce5a597,
@@ -6962,32 +6968,32 @@ PrefabInstance:
     - target: {fileID: 2101581890725928669, guid: 6a93edebbeca86d46817f4337f4e5e36,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 1
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 2101581890725928669, guid: 6a93edebbeca86d46817f4337f4e5e36,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 2101581890725928669, guid: 6a93edebbeca86d46817f4337f4e5e36,
         type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 2101581890725928669, guid: 6a93edebbeca86d46817f4337f4e5e36,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 2101581890725928669, guid: 6a93edebbeca86d46817f4337f4e5e36,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: -300
+      value: 450
       objectReference: {fileID: 0}
     - target: {fileID: 2101581890725928669, guid: 6a93edebbeca86d46817f4337f4e5e36,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: -600
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2101581890725928669, guid: 6a93edebbeca86d46817f4337f4e5e36,
         type: 3}

--- a/Assets/MyAssets/Prefab/Point/ColliderPointRoot.prefab
+++ b/Assets/MyAssets/Prefab/Point/ColliderPointRoot.prefab
@@ -112,7 +112,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   breakTileText: {fileID: 0}
-  gameToResultScreenChanger: {fileID: 0}
+  screenController: {fileID: 0}
 --- !u!1 &4052745119831440413
 GameObject:
   m_ObjectHideFlags: 0
@@ -184,7 +184,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 1800}
+  m_AnchoredPosition: {x: 0, y: 1000}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!65 &5947495968613686368

--- a/Assets/MyAssets/Prefab/SceneRoot/GameSceneRoot.prefab
+++ b/Assets/MyAssets/Prefab/SceneRoot/GameSceneRoot.prefab
@@ -1,5 +1,79 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &703893178815292751
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6918991347202667752}
+  - component: {fileID: 7076389108360090162}
+  - component: {fileID: 1260007602045101967}
+  m_Layer: 0
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6918991347202667752
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 703893178815292751}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6090127756866800044}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: 300}
+  m_SizeDelta: {x: 50, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7076389108360090162
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 703893178815292751}
+  m_CullTransparentMesh: 0
+--- !u!114 &1260007602045101967
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 703893178815292751}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!95 &4481406892070911196
 Animator:
   serializedVersion: 3
@@ -52,7 +126,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 100}
-  m_SizeDelta: {x: 180, y: 200}
+  m_SizeDelta: {x: 180, y: 250}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &7341908639467010325
 GameObject:
@@ -125,6 +199,7 @@ RectTransform:
   - {fileID: 5629753486037589486}
   - {fileID: 5580892586035277628}
   - {fileID: 143273255489356481}
+  - {fileID: 6918991347202667752}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1207,8 +1282,8 @@ PrefabInstance:
     - target: {fileID: 2139018580351524789, guid: cd9a8376674b2d9449e193f9d5ca91c1,
         type: 3}
       propertyPath: offset
-      value: 255
-      objectReference: {fileID: 0}
+      value: 
+      objectReference: {fileID: 6918991347202667752}
     - target: {fileID: 2193852081042333139, guid: cd9a8376674b2d9449e193f9d5ca91c1,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -2867,8 +2942,8 @@ PrefabInstance:
     - target: {fileID: 6600737606128174910, guid: cd9a8376674b2d9449e193f9d5ca91c1,
         type: 3}
       propertyPath: offset
-      value: 255
-      objectReference: {fileID: 0}
+      value: 
+      objectReference: {fileID: 6918991347202667752}
     - target: {fileID: 6623798252740387834, guid: cd9a8376674b2d9449e193f9d5ca91c1,
         type: 3}
       propertyPath: m_Pivot.x
@@ -4217,22 +4292,22 @@ PrefabInstance:
     - target: {fileID: 2992031085592266092, guid: ff70dc2bd8e0abd44ae83a3b5e952662,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 1
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 2992031085592266092, guid: ff70dc2bd8e0abd44ae83a3b5e952662,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 2992031085592266092, guid: ff70dc2bd8e0abd44ae83a3b5e952662,
         type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 2992031085592266092, guid: ff70dc2bd8e0abd44ae83a3b5e952662,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 2992031085592266092, guid: ff70dc2bd8e0abd44ae83a3b5e952662,
         type: 3}
@@ -4531,18 +4606,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 431f0790415d56643845eb2d9d159f49, type: 3}
---- !u!1 &4435464649332355122 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7296896852132907412, guid: 431f0790415d56643845eb2d9d159f49,
-    type: 3}
-  m_PrefabInstance: {fileID: 6399094589030775206}
-  m_PrefabAsset: {fileID: 0}
---- !u!224 &2638489370751371199 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 8958761942869753369, guid: 431f0790415d56643845eb2d9d159f49,
-    type: 3}
-  m_PrefabInstance: {fileID: 6399094589030775206}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &8250861158347099460 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3048607222102062306, guid: 431f0790415d56643845eb2d9d159f49,
@@ -4555,6 +4618,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &4435464649332355122 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7296896852132907412, guid: 431f0790415d56643845eb2d9d159f49,
+    type: 3}
+  m_PrefabInstance: {fileID: 6399094589030775206}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &2638489370751371199 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8958761942869753369, guid: 431f0790415d56643845eb2d9d159f49,
+    type: 3}
+  m_PrefabInstance: {fileID: 6399094589030775206}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &7712550672231538379
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5010,28 +5085,16 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 8112574380886064866}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &8236251703871685271 stripped
+--- !u!114 &7405633574265870690 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 205103050633755765, guid: ef96af57238497448983245ecf6475f7,
+  m_CorrespondingSourceObject: {fileID: 1608839588958644096, guid: ef96af57238497448983245ecf6475f7,
     type: 3}
   m_PrefabInstance: {fileID: 8112574380886064866}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9782ae049ead00047810a043f3411df0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &904249398726141816 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8942228439651015066, guid: ef96af57238497448983245ecf6475f7,
-    type: 3}
-  m_PrefabInstance: {fileID: 8112574380886064866}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 978a486d8ecf8437cbb87e8534908895, type: 3}
+  m_Script: {fileID: 11500000, guid: 9474d50c55f596441b3cf3112f47fe54, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &1856100203098771986 stripped
@@ -5046,15 +5109,27 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 74ae431eff8434b0897d3f7f1cff4311, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &7405633574265870690 stripped
+--- !u!114 &904249398726141816 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 1608839588958644096, guid: ef96af57238497448983245ecf6475f7,
+  m_CorrespondingSourceObject: {fileID: 8942228439651015066, guid: ef96af57238497448983245ecf6475f7,
     type: 3}
   m_PrefabInstance: {fileID: 8112574380886064866}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9474d50c55f596441b3cf3112f47fe54, type: 3}
+  m_Script: {fileID: 11500000, guid: 978a486d8ecf8437cbb87e8534908895, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &8236251703871685271 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 205103050633755765, guid: ef96af57238497448983245ecf6475f7,
+    type: 3}
+  m_PrefabInstance: {fileID: 8112574380886064866}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9782ae049ead00047810a043f3411df0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 

--- a/Assets/MyAssets/Prefab/Tile/GoldTiles/GoldTileGroup.prefab
+++ b/Assets/MyAssets/Prefab/Tile/GoldTiles/GoldTileGroup.prefab
@@ -86,7 +86,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 79b987af82670da469ef644b26bb4aea, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  maxSpeed: 50
+  maxSpeed: 60
   gameEndSpeed: 0
   playerHitChecker: {fileID: 0}
   playerController: {fileID: 0}

--- a/Assets/MyAssets/Prefab/Tile/GoldTiles/GoldTileGroupList.prefab
+++ b/Assets/MyAssets/Prefab/Tile/GoldTiles/GoldTileGroupList.prefab
@@ -96,7 +96,7 @@ MonoBehaviour:
   - {fileID: 2106474307268829218}
   - {fileID: 2627313775696870009}
   lastGroup: {fileID: 5482168691905630219}
-  offset: 255
+  offSetRectTransform: {fileID: 2798446676974074099}
 --- !u!1001 &91851658855500338
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/MyAssets/Prefab/Tile/NormalTiles/NormalTileGroup.prefab
+++ b/Assets/MyAssets/Prefab/Tile/NormalTiles/NormalTileGroup.prefab
@@ -86,7 +86,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 79b987af82670da469ef644b26bb4aea, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  maxSpeed: 50
+  maxSpeed: 80
   gameEndSpeed: 0
   playerHitChecker: {fileID: 0}
   playerController: {fileID: 0}

--- a/Assets/MyAssets/Prefab/Tile/NormalTiles/NormalTileGroupList.prefab
+++ b/Assets/MyAssets/Prefab/Tile/NormalTiles/NormalTileGroupList.prefab
@@ -96,7 +96,7 @@ MonoBehaviour:
   - {fileID: 754371193483128870}
   - {fileID: 4070114345846867989}
   lastGroup: {fileID: 5771776316253135463}
-  offset: 255
+  offSetRectTransform: {fileID: 2198126110275351}
 --- !u!1001 &1041824975811870610
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/MyAssets/Script/TileGroupManager.cs
+++ b/Assets/MyAssets/Script/TileGroupManager.cs
@@ -11,9 +11,10 @@ public class TileGroupManager : MonoBehaviour
     // 一番最後尾の瓦グループオブジェクト
     [SerializeField] GameObject lastGroup = default;
     // ポジションリセット時の間隔
-    [SerializeField] float offset = 232.5f;
+    [SerializeField] RectTransform offSetRectTransform = default;
     // 生成されたときに最後尾のグループを保存する
     GameObject keepLastGroup = default;
+
 
     /// <summary>
     /// 初期化処理
@@ -44,7 +45,7 @@ public class TileGroupManager : MonoBehaviour
     void Reposition(GameObject hitObject)
     {
         Vector3 position = hitObject.transform.position;
-        position.y = lastGroup.transform.position.y - offset;
+        position.y = lastGroup.transform.position.y - offSetRectTransform.rect.height;
         hitObject.transform.position = position;
         lastGroup = hitObject.gameObject;
     }

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -233,6 +233,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 74ae431eff8434b0897d3f7f1cff4311, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!224 &1065870381 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1711128048203591011, guid: 89116517d9e399545953c2a16e3dde80,
+    type: 3}
+  m_PrefabInstance: {fileID: 1556103609}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1329265332
 GameObject:
   m_ObjectHideFlags: 0
@@ -299,6 +305,12 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!224 &1555792078 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3974699117573738486, guid: 89116517d9e399545953c2a16e3dde80,
+    type: 3}
+  m_PrefabInstance: {fileID: 1556103609}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1556103609
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -324,32 +336,32 @@ PrefabInstance:
     - target: {fileID: 263949709457257138, guid: 89116517d9e399545953c2a16e3dde80,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 1
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 263949709457257138, guid: 89116517d9e399545953c2a16e3dde80,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 263949709457257138, guid: 89116517d9e399545953c2a16e3dde80,
         type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 263949709457257138, guid: 89116517d9e399545953c2a16e3dde80,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 263949709457257138, guid: 89116517d9e399545953c2a16e3dde80,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: -750
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 263949709457257138, guid: 89116517d9e399545953c2a16e3dde80,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: -600
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 967765959934542951, guid: 89116517d9e399545953c2a16e3dde80,
         type: 3}
@@ -414,8 +426,18 @@ PrefabInstance:
     - target: {fileID: 1251135563612914593, guid: 89116517d9e399545953c2a16e3dde80,
         type: 3}
       propertyPath: offset
-      value: 255
-      objectReference: {fileID: 0}
+      value: 
+      objectReference: {fileID: 1555792078}
+    - target: {fileID: 1251135563612914593, guid: 89116517d9e399545953c2a16e3dde80,
+        type: 3}
+      propertyPath: rectTransform
+      value: 
+      objectReference: {fileID: 1065870381}
+    - target: {fileID: 1251135563612914593, guid: 89116517d9e399545953c2a16e3dde80,
+        type: 3}
+      propertyPath: offSetRectTransform
+      value: 
+      objectReference: {fileID: 1065870381}
     - target: {fileID: 1270345806438226798, guid: 89116517d9e399545953c2a16e3dde80,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -459,7 +481,7 @@ PrefabInstance:
     - target: {fileID: 1805135064351581936, guid: 89116517d9e399545953c2a16e3dde80,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 200
+      value: 250
       objectReference: {fileID: 0}
     - target: {fileID: 1805135064351581936, guid: 89116517d9e399545953c2a16e3dde80,
         type: 3}
@@ -566,6 +588,36 @@ PrefabInstance:
       propertyPath: screenTransformGesture
       value: 
       objectReference: {fileID: 790822817}
+    - target: {fileID: 3974699117573738486, guid: 89116517d9e399545953c2a16e3dde80,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3974699117573738486, guid: 89116517d9e399545953c2a16e3dde80,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3974699117573738486, guid: 89116517d9e399545953c2a16e3dde80,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3974699117573738486, guid: 89116517d9e399545953c2a16e3dde80,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3974699117573738486, guid: 89116517d9e399545953c2a16e3dde80,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3974699117573738486, guid: 89116517d9e399545953c2a16e3dde80,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 300
+      objectReference: {fileID: 0}
     - target: {fileID: 4004291032491957073, guid: 89116517d9e399545953c2a16e3dde80,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -649,32 +701,32 @@ PrefabInstance:
     - target: {fileID: 5334399036683302221, guid: 89116517d9e399545953c2a16e3dde80,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 1
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 5334399036683302221, guid: 89116517d9e399545953c2a16e3dde80,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 5334399036683302221, guid: 89116517d9e399545953c2a16e3dde80,
         type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 5334399036683302221, guid: 89116517d9e399545953c2a16e3dde80,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 5334399036683302221, guid: 89116517d9e399545953c2a16e3dde80,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: -702
+      value: 48
       objectReference: {fileID: 0}
     - target: {fileID: 5334399036683302221, guid: 89116517d9e399545953c2a16e3dde80,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: -600
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5688036974245783820, guid: 89116517d9e399545953c2a16e3dde80,
         type: 3}
@@ -839,37 +891,47 @@ PrefabInstance:
     - target: {fileID: 6298628067741178666, guid: 89116517d9e399545953c2a16e3dde80,
         type: 3}
       propertyPath: offset
-      value: 255
-      objectReference: {fileID: 0}
+      value: 
+      objectReference: {fileID: 1555792078}
+    - target: {fileID: 6298628067741178666, guid: 89116517d9e399545953c2a16e3dde80,
+        type: 3}
+      propertyPath: rectTransform
+      value: 
+      objectReference: {fileID: 1923706945}
+    - target: {fileID: 6298628067741178666, guid: 89116517d9e399545953c2a16e3dde80,
+        type: 3}
+      propertyPath: offSetRectTransform
+      value: 
+      objectReference: {fileID: 1923706945}
     - target: {fileID: 6658040906407791111, guid: 89116517d9e399545953c2a16e3dde80,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 1
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 6658040906407791111, guid: 89116517d9e399545953c2a16e3dde80,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 6658040906407791111, guid: 89116517d9e399545953c2a16e3dde80,
         type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 6658040906407791111, guid: 89116517d9e399545953c2a16e3dde80,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 6658040906407791111, guid: 89116517d9e399545953c2a16e3dde80,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: -750
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6658040906407791111, guid: 89116517d9e399545953c2a16e3dde80,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: -600
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6731761514728889995, guid: 89116517d9e399545953c2a16e3dde80,
         type: 3}
@@ -904,32 +966,42 @@ PrefabInstance:
     - target: {fileID: 6889124143965180063, guid: 89116517d9e399545953c2a16e3dde80,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 1
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 6889124143965180063, guid: 89116517d9e399545953c2a16e3dde80,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 6889124143965180063, guid: 89116517d9e399545953c2a16e3dde80,
         type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 6889124143965180063, guid: 89116517d9e399545953c2a16e3dde80,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 6889124143965180063, guid: 89116517d9e399545953c2a16e3dde80,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: -750
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6889124143965180063, guid: 89116517d9e399545953c2a16e3dde80,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: -600
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7067210279419123263, guid: 89116517d9e399545953c2a16e3dde80,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 7067210279419123263, guid: 89116517d9e399545953c2a16e3dde80,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 300
       objectReference: {fileID: 0}
     - target: {fileID: 7340385123223974759, guid: 89116517d9e399545953c2a16e3dde80,
         type: 3}
@@ -994,7 +1066,7 @@ PrefabInstance:
     - target: {fileID: 8324859062678432456, guid: 89116517d9e399545953c2a16e3dde80,
         type: 3}
       propertyPath: m_Enabled
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8404015046716500027, guid: 89116517d9e399545953c2a16e3dde80,
         type: 3}
@@ -1085,3 +1157,9 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 3}
+--- !u!224 &1923706945 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5875772638510773736, guid: 89116517d9e399545953c2a16e3dde80,
+    type: 3}
+  m_PrefabInstance: {fileID: 1556103609}
+  m_PrefabAsset: {fileID: 0}

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -546,7 +546,7 @@ PlayerSettings:
   webGLThreadsSupport: 0
   webGLWasmStreaming: 0
   scriptingDefineSymbols:
-    1: TOUCHSCRIPT_DEBUG
+    1: 
   platformArchitecture: {}
   scriptingBackend: {}
   il2cppCompilerConfiguration: {}


### PR DESCRIPTION
解像度変更した際にタイルグループ間に隙間が空いてしまう不具合修正
タイルグループの幅を用いて解決しました。
確認点
Script
・TileGroupManager
Prefab
・GameCanvas
・ColliderPointRoot
・GameSceneRoot
・GoldTileGroup
・NormalTileGroup
確認方法
GameSceneをプレイして解像度を変更してもタイル間に隙間が出ないかを確認
